### PR TITLE
Fix testrunner

### DIFF
--- a/libgambatte/SConstruct
+++ b/libgambatte/SConstruct
@@ -29,7 +29,6 @@ sourceFiles = Split('''
 			src/mem/memptrs.cpp
 			src/mem/pakinfo.cpp
 			src/mem/rtc.cpp
-			src/mem/sgb.cpp
 			src/mem/time.cpp
 			src/sound/channel1.cpp
 			src/sound/channel2.cpp
@@ -44,6 +43,8 @@ sourceFiles = Split('''
 			src/video/ppu.cpp
 			src/video/sprite_mapper.cpp
 		   ''')
+
+# src/mem/sgb.cpp functionality effectively removed
 
 conf = env.Configure()
 

--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -23,7 +23,7 @@
 #include "loadres.h"
 #include <cstddef>
 #include <string>
-#include "newstate.h"
+#include "../src/newstate.h"
 
 namespace gambatte {
 

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -69,7 +69,7 @@ void GB::blitTo(gambatte::uint_least32_t *videoBuf, std::ptrdiff_t pitch) {
 
 	for (int i = 0; i < 144; i++)
 	{
-		std::memcpy(dst, src, sizeof gambatte::uint_least32_t * 160);
+		std::memcpy(dst, src, sizeof (gambatte::uint_least32_t) * 160);
 		src += 160;
 		dst += pitch;
 	}

--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -291,25 +291,27 @@ static void runTestRom(
 		std::size_t const biossize = bios->size();
 		char biosdata[biossize];
 		bios->read(reinterpret_cast<char *>(biosdata), sizeof biosdata);
-		if (biossize != 0x900 || (crc32(0, (const unsigned char*)biosdata, biossize) != 0x41884E46)) {
+		if (biossize == 0x900 && (crc32(0, (unsigned char*)biosdata, biossize) == 0x41884E46))
+			gb.loadBios(biosdata, 0x900);
+		else {
 			std::fprintf(stderr, "Failed to load bios image file bios.gbc\n");
 			std::abort();
 		}
-		gb.loadBios(biosdata, 0x900);
 	} else {
 		scoped_ptr<gambatte::File> const bios(gambatte::newFileInstance("bios.gb"));
-		if (bios->fail() ) {
+		if (bios->fail()) {
 			std::fprintf(stderr, "Failed to load bios image file bios.gb\n");
 			std::abort();
 		}
 		std::size_t const biossize = bios->size();
 		char biosdata[biossize];
 		bios->read(reinterpret_cast<char *>(biosdata), sizeof biosdata);
-		if (biossize != 0x100 || (crc32(0, (const unsigned char*)biosdata, biossize) != 0x59C8598E)) {
+		if (biossize == 0x100 && (crc32(0, (unsigned char*)biosdata, biossize) == 0x59C8598E))
+			gb.loadBios(biosdata, 0x100);
+		else {
 			std::fprintf(stderr, "Failed to load bios image file bios.gb\n");
 			std::abort();
 		}
-		gb.loadBios(biosdata, 0x100);
 	}
 
 	scoped_ptr<gambatte::File> const rom(gambatte::newFileInstance(file));

--- a/test/testrunner.cpp
+++ b/test/testrunner.cpp
@@ -291,7 +291,7 @@ static void runTestRom(
 		std::size_t const biossize = bios->size();
 		char biosdata[biossize];
 		bios->read(reinterpret_cast<char *>(biosdata), sizeof biosdata);
-		if (biossize == 0x900 && (crc32(0, (unsigned char*)biosdata, biossize) == 0x41884E46))
+		if ((biossize == 0x900) && (crc32(0, (unsigned char*)biosdata, biossize) == 0x41884E46))
 			gb.loadBios(biosdata, 0x900);
 		else {
 			std::fprintf(stderr, "Failed to load bios image file bios.gbc\n");
@@ -306,7 +306,7 @@ static void runTestRom(
 		std::size_t const biossize = bios->size();
 		char biosdata[biossize];
 		bios->read(reinterpret_cast<char *>(biosdata), sizeof biosdata);
-		if (biossize == 0x100 && (crc32(0, (unsigned char*)biosdata, biossize) == 0x59C8598E))
+		if ((biossize == 0x100) && (crc32(0, (unsigned char*)biosdata, biossize) == 0x59C8598E))
 			gb.loadBios(biosdata, 0x100);
 		else {
 			std::fprintf(stderr, "Failed to load bios image file bios.gb\n");
@@ -315,6 +315,10 @@ static void runTestRom(
 	}
 
 	scoped_ptr<gambatte::File> const rom(gambatte::newFileInstance(file));
+	if (rom->fail()) {
+		std::fprintf(stderr, "Failed to load ROM image file %s\n", file.c_str());
+		std::abort();
+	}
 	std::size_t const filesize = rom->size();
 	char romdata[filesize];
 	rom->read(reinterpret_cast<char *>(romdata), sizeof romdata);


### PR DESCRIPTION
Does some non-functional changes within the core so gcc can actually build libgambatte and several hacky measures are put into the testrunner to conform to bizhawk's version of gambatte